### PR TITLE
Caching Docker image with gha backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@
 
 ## How it works
 The Github Workflow triggers within Pull Requests targeted to the `main` branch.
-The workflow will build a Docker image defined in `docker/Dockerfile` on each commit pushed to the Pull Request.
+When triggered, the workflow will build a Docker image defined in `docker/Dockerfile` on each commit pushed to the Pull Request.
 
 The [Github Actions cache](https://docs.docker.com/build/cache/backends/gha/) backend is used to store any build results from Docker. This cache will be used in subsequent builds within the pull request. Note that the cache is not used between separate PRs. Therefore, a full build is required for the first commit of a new pull request.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,3 +5,5 @@ RUN echo "Sleep for 1 minute" && sleep 1m
 
 RUN echo "2"
 RUN echo "Sleep for 2 minutes" && sleep 2m
+
+RUN echo "3"


### PR DESCRIPTION
An example PR using the `gha` backend to cache Docker images.

There are two workflow instances that ran within this PR. The first one took 3m 30s to run:
![image](https://github.com/rolzy/gha-docker-cache-example/assets/10916857/114ca92c-6e8d-4873-9bde-e69250ba452d)

At the end of the first actions, we see that the `build-push-action` action has uploaded the Docker cache to the Github Actions cache storage: 
![image](https://github.com/rolzy/gha-docker-cache-example/assets/10916857/b6b2a0d3-e98d-45b1-8dbc-23a48986c278)

Thanks to this, the second run only took 20 seconds, and all immediate steps were cached: 
![image](https://github.com/rolzy/gha-docker-cache-example/assets/10916857/a5556d1e-efa7-441b-b73c-2105651cd143)
